### PR TITLE
Fixed invalid version set for pygment-github-lexers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 linguist==0.1.1
 Pygments==2.1.3
-pygments-github-lexers==0.1
+pygments-github-lexers==0.0.5
 scanner==0.0.5
 mime==0.0.3


### PR DESCRIPTION
As mentioned in https://github.com/alt-code/DockerizeMe/issues/10, the pygment-github-lexers==0.1 is invalid and causing the docker build command to fail. Thus fixed it by correcting the version.